### PR TITLE
Improved HTTPS server initialization with dynamic SSL check

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,15 +34,22 @@ app.listen(80, function () {
   console.log(`Server listening on port 80`);
 });
 
-// SSL certificate files
-const privateKey = fs.readFileSync('ssl/jcmmetais.ddns.net-PrivateKey.key', 'utf8');
-const certificate = fs.readFileSync('ssl/jcmmetais.ddns.net-cloudflare.pem', 'utf8');
+const httpsServer = null;
 
-const credentials = {key: privateKey, cert: certificate};
+if (
+  fs.existsSync("./ssl/jcmmetais.ddns.net-PrivateKey.key") &&
+  fs.existsSync("./ssl/jcmmetais.ddns.net-cloudflare.pem")
+) {
+  httpsServer = https.createServer({
+    key: fs.readFileSync("./ssl/jcmmetais.ddns.net-PrivateKey.key"),
+    cert: fs.readFileSync("./ssl/jcmmetais.ddns.net-cloudflare.pem"),
+  }, app);
+  httpsServer.keepAliveTimeout = 60 * 1000 + 1000;
+  httpsServer.headersTimeout = 60 * 1000 + 2000;
 
-// Create HTTPS server
-const httpsServer = https.createServer(credentials, app);
+  httpsServer.listen(443, () => {
+    console.log('HTTPS server running on port 443');
+  })
+}
 
-httpsServer.listen(443, () => {
-  console.log('HTTPS server running on port 443');
-});
+


### PR DESCRIPTION
Introduced a conditional SSL certificate check before initializing the HTTPS server, enhancing server flexibility and robustness. This update dynamically checks for the existence of SSL certificate files before setting up the HTTPS server, avoiding potential startup errors when certificates are not present. As a result, the server can now gracefully handle the absence of SSL certificates by not attempting to start the HTTPS server, thus reducing startup failures and easing local development or situations where SSL isn't immediately available or necessary. This change further optimizes the server by setting specific timeouts for the HTTPS server, aiming to improve performance under various network conditions.

No specific issues associated with these changes were referenced.