### PR TITLE
fix(pedidocompra): handle file control state and add observacao field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jcmfront2",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/screen/home/pedidoscompras/pedidocompra/pedidocompra.component.ts
+++ b/src/app/screen/home/pedidoscompras/pedidocompra/pedidocompra.component.ts
@@ -117,6 +117,7 @@ export class PedidoCompraComponent implements OnInit, OnDestroy, AfterViewInit {
       createdAt: null,
       updatedAt: null,
       deletedAt: null,
+      observacao: null,
     },
     pedido_compra_items: {
       value: [
@@ -553,6 +554,10 @@ export class PedidoCompraComponent implements OnInit, OnDestroy, AfterViewInit {
       consoleLogDev(this.dynamicFormService.getAllErrors(this.pedidoCompra));
       return;
     }
+
+    if (!this.files.value[0]?.id && this.files.controls[0])
+      this.files.controls[0].disable()
+
     if (Number(this.id.value) == 0) {
       this.createPedido();
     } else {
@@ -564,9 +569,11 @@ export class PedidoCompraComponent implements OnInit, OnDestroy, AfterViewInit {
       .addPedidoCompra(this.pedidoCompra.value)
       .subscribe({
         next: (response) => {
-          // this.dynamicFormService.resizeForm(this.pedidoCompra, response);
+          if(this.files.controls[0])this.files.controls[0].enable();
+          consoleLogDev(this.pedidoCompra.value);
           consoleLogDev(response);
-          this.pedidoCompra.setValue(response);
+          this.dynamicFormService.resizeForm(this.pedidoCompra, response);
+          this.pedidoCompra.patchValue(response);
         },
         error: (error) => {
           console.error(error);
@@ -592,6 +599,9 @@ export class PedidoCompraComponent implements OnInit, OnDestroy, AfterViewInit {
       .updatePedidoCompra(this.pedidoCompra.value)
       .subscribe({
         next: (response) => {
+          if(this.files.controls[0])this.files.controls[0].enable();
+          consoleLogDev(this.pedidoCompra.value);
+          consoleLogDev(response);
           this.dynamicFormService.resizeForm(this.pedidoCompra, response);
           this.pedidoCompra.patchValue(response);
         },


### PR DESCRIPTION
Updated PedidoCompraComponent to manage the state of file controls during form submission. Added 'observacao' field to initial form data. Adjusted logic to enable/disable file controls based on conditions, ensuring proper form handling and logging. Bumped version to 1.16.1 in package.json.