### PR TITLE
fix(orcamento): handle undefined pessoa id in template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jcmfront2",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/screen/home/orcamentos/orcamento/orcamento.component.html
+++ b/src/app/screen/home/orcamentos/orcamento/orcamento.component.html
@@ -473,7 +473,7 @@
                 <p-cellEditor>
                   <ng-template pTemplate="input">
                     <input
-                      *ngIf="!orcamento.pessoa.id"
+                      *ngIf="!orcamento.pessoa?.id"
                       pInputText
                       class="p-inputtext"
                       [name]="'inpItemDescricao' + index"


### PR DESCRIPTION
Updated the version in package.json to 1.16.2 and fixed a bug in orcamento.component.html where an undefined pessoa id was not properly handled, preventing potential runtime errors.