### PR TITLE
fix(orcamento): correct conditional rendering for pessoa field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jcmfront2",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/screen/home/orcamentos/orcamento/orcamento.component.html
+++ b/src/app/screen/home/orcamentos/orcamento/orcamento.component.html
@@ -473,7 +473,7 @@
                 <p-cellEditor>
                   <ng-template pTemplate="input">
                     <input
-                      *ngIf="!orcamento.pessoa?.id"
+                      *ngIf="!orcamento.pessoa"
                       pInputText
                       class="p-inputtext"
                       [name]="'inpItemDescricao' + index"
@@ -483,7 +483,7 @@
                       [disabled]="orcamento.status !== 'Orçamento'"
                     />
                     <p-autoComplete
-                      *ngIf="orcamento.pessoa.id"
+                      *ngIf="orcamento.pessoa"
                       pInputText
                       class="p-autocomplete wv-100"
                       [name]="'searchItemDescricao' + index"


### PR DESCRIPTION
Updated the conditional checks in orcamento.component.html to properly handle cases where 'pessoa' is null or undefined. This ensures that the input and auto-complete fields render correctly based on the presence of 'pessoa'. Also incremented the version in package.json from 1.16.2 to 1.16.3.