### PR TITLE
fix(orcamento): add noprint class to input group addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jcmfront2",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "scripts": {
     "ng": "ng",
     "start": "node server.js",

--- a/src/app/screen/home/orcamentos/orcamento/orcamento.component.html
+++ b/src/app/screen/home/orcamentos/orcamento/orcamento.component.html
@@ -148,7 +148,7 @@
               </div>
             </ng-template></p-autoComplete
           >
-            <p-inputGroupAddon class="p-0">
+            <p-inputGroupAddon class="p-0 noprint">
               <button
                 type="button"
                 pButton
@@ -316,7 +316,7 @@
               [disabled]="orcamento.status !== 'Orçamento'"
               class="noprint flex-grow-1"
             ></p-autoComplete>
-            <p-inputGroupAddon class="p-0">
+            <p-inputGroupAddon class="p-0 noprint">
               <button
                 type="button"
                 pButton


### PR DESCRIPTION
Updated the orcamento component HTML to include the 'noprint' class on p-inputGroupAddon elements. This change ensures that certain buttons are not printed, improving the print layout. Also incremented the package version to 1.16.10.